### PR TITLE
Flatpak build/run tasks + Set RID when publishing

### DIFF
--- a/dotnet.cake
+++ b/dotnet.cake
@@ -32,6 +32,12 @@ Task("Run")
 Task("Publish")
     .Does(() =>
     {
+        var runtime = Argument("runtime", "");
+        if (string.IsNullOrEmpty(runtime))
+        {
+            runtime = IsRunningOnLinux() ? "linux-" : "win-";
+            runtime += System.Runtime.InteropServices.RuntimeInformation.ProcessArchitecture.ToString().ToLower();
+        }
         var outDir = EnvironmentVariable("NICK_BUILDDIR", "_nickbuild");
         CleanDirectory(outDir);
         if (!prefix.StartsWith(sep))
@@ -41,12 +47,14 @@ Task("Publish")
         var libDir = string.IsNullOrEmpty(prefix) ? "lib" : $"{prefix}{sep}lib";
         var publishDir = $"{outDir}{libDir}{sep}{appId}";
         var exitCode = 0;
+        Information($"Publishing {projectName}.{projectSuffix} ({runtime})...");
         DotNetPublish($"{projectName}.{projectSuffix}{sep}{projectName}.{projectSuffix}.csproj", new DotNetPublishSettings
         {
             Configuration = "Release",
             SelfContained = selfContained,
             OutputDirectory = publishDir,
             Sources = Argument("sources", "").Split(" "),
+            Runtime = runtime,
             HandleExitCode = code => {
                 exitCode = code;
                 return false;

--- a/flatpak.cake
+++ b/flatpak.cake
@@ -1,0 +1,27 @@
+
+Task("FlatpakBuild")
+    .Does(() =>
+    {
+        if (!IsRunningOnLinux())
+        {
+            throw new CakeException("This task can only be executed on Linux.");
+        }
+        StartProcess("flatpak", new ProcessSettings
+        {
+            Arguments = $"run org.flatpak.Builder --force-clean --disable-rofiles-fuse _build flatpak/{appId}.json"
+        });
+    });
+
+Task("FlatpakRun")
+    .Does(() =>
+    {
+        if (!IsRunningOnLinux())
+        {
+            throw new CakeException("This task can only be executed on Linux.");
+        }
+        var uid = EnvironmentVariable("UID", "1000");
+        StartProcess("flatpak", new ProcessSettings
+        {
+            Arguments = $"build --with-appdir --talk-name=org.freedesktop.portal.* --talk-name=org.a11y.Bus --bind-mount=/run/user/{uid}/doc=/run/user/{uid}/doc/by-app/{appId} _build {appId}"
+        });
+    });

--- a/main.cake
+++ b/main.cake
@@ -8,7 +8,7 @@ var projectSuffix = ui.ToLower() switch
     _ => ""
 };
 // Only some tasks require to set a project to work with
-var requiresUI = new string[] { "Clean", "Build", "Run", "Publish", "Flatpak" }.Any(target.Contains);
+var requiresUI = new string[] { "Clean", "Build", "Run", "Publish", "FlatpakSourcesGen" }.Any(t => t == target);
 if ((string.IsNullOrEmpty(projectSuffix) || !projectsToBuild.Contains(projectSuffix))  && requiresUI)
 {
     throw new CakeException($"Unknown UI. Possible values: {string.Join(", ", projectsToBuild)}.");
@@ -16,6 +16,7 @@ if ((string.IsNullOrEmpty(projectSuffix) || !projectsToBuild.Contains(projectSuf
 //Load tasks and run
 #load local:?path=docs.cake
 #load local:?path=dotnet.cake
+#load local:?path=flatpak.cake
 #load local:?path=gettext.cake
 #load local:?path=packaging.cake
 RunTarget(target);


### PR DESCRIPTION
IIRC not setting RID was causing some unneeded files to be generated, don't remember exactly, but anyway, no harm in adding this, we had it in Parabolic script previously.

`dotnet cake --target=FlatpakBuild`
(Re)builds flatpak (dependendies will get cached). Requires org.flatpak.Builder to be installed.

`dotnet cake --target=FlatpakRun`
Runs flatpak without installing.

Tested with Application and Parabolic.

Closes #1 